### PR TITLE
Added the ability to specify a new database to restore to.

### DIFF
--- a/ManagingTestData/sp_automate_restore.sql
+++ b/ManagingTestData/sp_automate_restore.sql
@@ -125,7 +125,7 @@ AS
  			    SET @LogicalNameData=(SELECT LogicalName FROM @Table WHERE Type='D')
 				SET @LogicalNameLog=(SELECT LogicalName FROM @Table WHERE Type='L')
                 SET @StorageFolder=(SELECT PhysicalName FROM @Table where Type='D')
-                SET @StorageFolder = SUBSTRING(@StorageFolder, 0, CHARINDEX('\', @StorageFolder, 4)+1) + 'Temp\'
+                SET @StorageFolder = SUBSTRING(@StorageFolder, 0, LEN(@StorageFolder) - LEN(REVERSE(SUBSTRING(REVERSE(@StorageFolder),0,CHARINDEX('\',REVERSE(@StorageFolder))))) + 1) + 'Temp\'
 
 				SET @cmd = 'RESTORE DATABASE ' + @dbName + ' FROM DISK = '''
 					+ @backupPath + @lastFullBackup + ''' WITH REPLACE, NORECOVERY,'

--- a/ManagingTestData/sp_automate_restore.sql
+++ b/ManagingTestData/sp_automate_restore.sql
@@ -44,7 +44,7 @@ GO
 -- 07222015 - Modified by Andy Garrett to allow database to be restored to new database.  To restore, pass in name of the new database using the @NewDatabaseName variable.
 --          - Also modified to take into account any spaces in the name of the database, as the scripts by Ola removes spaces.  This was causing the Path to the backups to fail
 -- =============================================
-ALTER PROCEDURE [dbo].[sp_automate_restore]
+CREATE PROCEDURE [dbo].[sp_automate_restore]
     @DatabaseName VARCHAR(255)
    ,@UncPath VARCHAR(255)
    ,@DebugLevel INT

--- a/ManagingTestData/sp_automate_restore.sql
+++ b/ManagingTestData/sp_automate_restore.sql
@@ -119,16 +119,18 @@ AS
 							[BackupSizeInBytes]varchar(128), [SourceBlockSize]varchar(128), [FileGroupId]varchar(128), [LogGroupGUID]varchar(128), [DifferentialBaseLSN]varchar(128), [DifferentialBaseGUID]varchar(128), [IsReadOnly]varchar(128), [IsPresent]varchar(128), [TDEThumbprint]varchar(128)
 				)
 				DECLARE @Path varchar(1000)='' + @backupPath + @lastFullBackup + ''
-				DECLARE @LogicalNameData varchar(128),@LogicalNameLog varchar(128)
+				DECLARE @LogicalNameData varchar(128),@LogicalNameLog varchar(128),@StorageFolder varchar(128)
 				INSERT INTO @table
 				EXEC('RESTORE FILELISTONLY FROM DISK=''' +@Path+ '''')
  			    SET @LogicalNameData=(SELECT LogicalName FROM @Table WHERE Type='D')
-				SET @LogicalNameLog=(SELECT LogicalName FROM @Table WHERE Type='L') 
+				SET @LogicalNameLog=(SELECT LogicalName FROM @Table WHERE Type='L')
+                SET @StorageFolder=(SELECT PhysicalName FROM @Table where Type='D')
+                SET @StorageFolder = SUBSTRING(@StorageFolder, 0, CHARINDEX('\', @StorageFolder, 4)+1) + 'Temp\'
 
 				SET @cmd = 'RESTORE DATABASE ' + @dbName + ' FROM DISK = '''
 					+ @backupPath + @lastFullBackup + ''' WITH REPLACE, NORECOVERY,'
-					+ 'MOVE ''' + @LogicalNameData + ''' TO ''C:\SQLDATAStore\Temp\' + @dbName + '.mdf'', ' 
-					+ 'MOVE ''' + @LogicalNameLog + ''' TO ''C:\SQLDATAStore\Temp\' + @dbName + '.ldf''; ' 
+					+ 'MOVE ''' + @LogicalNameData + ''' TO ''' + @StorageFolder + @dbName + '.mdf'', ' 
+					+ 'MOVE ''' + @LogicalNameLog + ''' TO ''' + @StorageFolder + @dbName + '.ldf''; ' 
 			END
         IF (@DebugLevel = 2
             OR @DebugLevel = 3


### PR DESCRIPTION
The major change included in this commit, is the ability to specify a new database to restore your backup to in order to retrieve single record(s) that may have been deleted vs overwriting the current database.   The restore will create a new database and then move the data and LOG files to the new FILES during on the last FULL backup, and then restore the DIFF and Transaction files to the new databases.

Minor Changed:
Changed the way the script gets the  Server Name for folder identification to match  how Ola Hallagren's script looks up the server name: CAST(SERVERPROPERTY('ServerName') AS nvarchar)
